### PR TITLE
feat: jsonp支持callback为空时返回json格式

### DIFF
--- a/packages/app/src/controller/index.controller.ts
+++ b/packages/app/src/controller/index.controller.ts
@@ -67,4 +67,8 @@ export default class Index extends BaseController {
         const rs = fs.createReadStream(path.resolve(__dirname, './template.controller.ts'));
         return Result.stream(rs, 'controller.ts');
     }
+    @Path('/jsonp')
+    jsonp() {
+        return Result.jsonp({"data":1});
+    }
 }

--- a/packages/core/src/extends/Context.ts
+++ b/packages/core/src/extends/Context.ts
@@ -13,10 +13,14 @@ export const Context: BaseContext = {
     },
 
     jsonp(data: Object, callbackField: string = 'callback') {
-        const field = (this.query[callbackField] || 'callback').replace(/[^\w.]/g, '');
+        const field = (this.query[callbackField] || '').replace(/[^\w.]/g, '');
 
-        this.type = 'application/javascript';
-        this.body = `${field}(${JSON.stringify(data)})`;
+        if (field) {
+            this.type = 'application/javascript';
+            this.body = `${field}(${JSON.stringify(data)})`;
+        } else {
+            this.json(data);
+        }
     },
 
     view(viewPath: string, locals: any = {}) {


### PR DESCRIPTION
使用场景中接口需要支持json和jsonp两种形式，为了避免在接口中判断callback为空逻辑，jsonp默认支持两种格式：

eg:减少以下用法
```
        if (callback) {
            return Result.jsonp(resultJson);
        }

        return Result.json(resultJson);
```

- 修复理由：

>前端请求库jquery或者fetchJsonp都默认会传递callback ，所以如果业务需要使用jsonp则callback肯定有值。原则上不会影响jsonp功能和理解成本的增加。